### PR TITLE
Cache score element once

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,6 +74,7 @@
 
         const audioContext = new (window.AudioContext || window.webkitAudioContext)();
         const backgroundMusic = document.getElementById("backgroundMusic");
+        const scoreEl = document.getElementById("score");
         let isAudioUnlocked = false;
 
         function unlockAudio() {
@@ -402,7 +403,7 @@
         }
 
         function updateScoreDisplay() {
-          document.getElementById("score").textContent = score;
+          scoreEl.textContent = score;
         }
 
         function update() {


### PR DESCRIPTION
## Summary
- cache `scoreEl` once on page load
- use cached `scoreEl` in `updateScoreDisplay`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686d806466fc83259fda989af0e019ee

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized score display updates for better responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->