### PR TITLE
Fix passive touchstart

### DIFF
--- a/index.html
+++ b/index.html
@@ -611,7 +611,7 @@
         }
 
         canvas.addEventListener("mousedown", handleInput);
-        canvas.addEventListener("touchstart", handleInput);
+        canvas.addEventListener("touchstart", handleInput, { passive: false });
 
         init();
       })();


### PR DESCRIPTION
## Summary
- add `{ passive: false }` to the `touchstart` listener so that `event.preventDefault()` functions on mobile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d925c25f88325977b260f902734f7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved touch interaction on the canvas for touch devices by preventing unintended browser behaviors like scrolling or zooming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->